### PR TITLE
Postgres persistence

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,14 @@ jobs:
         image: mongo:3.2
         ports:
           - 27017:27017
+      postgres:
+        image: postgres:14
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sdkman
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,14 @@ jobs:
         image: mongo:3.2
         ports:
           - 27017:27017
+      postgres:
+        image: postgres:14
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sdkman
     steps:
     - uses: actions/checkout@v2
       with:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,16 @@ Used by vendors for releasing new candidate versions on SDKMAN!
 
 ### Test
 
-    $ sbt acc:test
+    $ sbt test
 
 ### Run locally
 
     $ docker run --rm -d -p="27017:27017" --name=mongo mongo:3.2
+    $ docker run \
+        --name postgres \
+        -p 5432:5432 \
+        -e POSTGRES_USER=postgres \
+        -e POSTGRES_PASSWORD=postgres \
+        -e POSTGRES_DB=sdkman \
+        -d postgres
     $ sbt run

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,9 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.1.8",
   "io.spray" %% "spray-json" % "1.3.2",
   "com.github.sdkman" % "sdkman-mongodb-persistence" % "2.1",
-  "com.github.sdkman" % "sdkman-url-validator" % "0.2.4"
+  "com.github.sdkman" % "sdkman-url-validator" % "0.2.4",
+  "org.flywaydb" % "flyway-core" % "9.16.0",
+  "org.postgresql" % "postgresql" % "42.5.4"
 ) ++ testDependencies
 
 lazy val `vendor-release` = (project in file("."))

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -38,7 +38,7 @@ jdbc {
     url = ${?DATABASE_URL}
 
     username = "postgres"
-    username = ${?DATABASE_USERNAME}
+    username = ${?DATABASE_USER}
 
     password = "postgres"
     password = ${?DATABASE_PASSWORD}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -32,3 +32,14 @@ mongo {
   password = ""
   password = ${?MONGO_PASSWORD}
 }
+
+jdbc {
+    url = "jdbc:postgresql://localhost:5432/sdkman"
+    url = ${?DATABASE_URL}
+
+    username = "postgres"
+    username = ${?DATABASE_USERNAME}
+
+    password = "postgres"
+    password = ${?DATABASE_PASSWORD}
+}

--- a/src/main/resources/db/migration/V1__create_version_table.sql
+++ b/src/main/resources/db/migration/V1__create_version_table.sql
@@ -1,9 +1,10 @@
-CREATE TABLE version(
-    id SERIAL PRIMARY KEY,
+CREATE TABLE version
+(
+    id        SERIAL PRIMARY KEY,
     candidate TEXT,
-    version TEXT,
-    platform TEXT,
-    visible BOOLEAN,
-    url TEXT,
+    version   TEXT,
+    platform  TEXT,
+    visible   BOOLEAN,
+    url       TEXT,
     UNIQUE (candidate, version, platform)
 )

--- a/src/main/resources/db/migration/V1__create_version_table.sql
+++ b/src/main/resources/db/migration/V1__create_version_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE version(
+    id SERIAL PRIMARY KEY,
+    candidate TEXT,
+    version TEXT,
+    platform TEXT,
+    visible BOOLEAN,
+    url TEXT,
+    UNIQUE (candidate, version, platform)
+)

--- a/src/main/resources/db/migration/V1__create_versions.sql
+++ b/src/main/resources/db/migration/V1__create_versions.sql
@@ -1,0 +1,8 @@
+CREATE TABLE versions(
+    id SERIAL PRIMARY KEY,
+    candidate TEXT,
+    version TEXT,
+    url TEXT,
+    platform TEXT,
+    visible BOOLEAN
+)

--- a/src/main/resources/db/migration/V1__create_versions.sql
+++ b/src/main/resources/db/migration/V1__create_versions.sql
@@ -1,8 +1,0 @@
-CREATE TABLE versions(
-    id SERIAL PRIMARY KEY,
-    candidate TEXT,
-    version TEXT,
-    url TEXT,
-    platform TEXT,
-    visible BOOLEAN
-)

--- a/src/main/resources/db/migration/V2__create_candidate_table.sql
+++ b/src/main/resources/db/migration/V2__create_candidate_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE candidate
+(
+    id              TEXT PRIMARY KEY,
+    name            TEXT,
+    description     TEXT,
+    default_version TEXT,
+    website_url     TEXT,
+    distribution    TEXT
+)

--- a/src/main/scala/io/sdkman/vendor/release/Configuration.scala
+++ b/src/main/scala/io/sdkman/vendor/release/Configuration.scala
@@ -15,11 +15,11 @@
   */
 package io.sdkman.vendor.release
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 
 trait Configuration {
 
-  lazy val config = ConfigFactory.load()
+  lazy val config: Config = ConfigFactory.load()
 
   lazy val serviceHost: String = config.getString("service.host")
 

--- a/src/main/scala/io/sdkman/vendor/release/Configuration.scala
+++ b/src/main/scala/io/sdkman/vendor/release/Configuration.scala
@@ -19,7 +19,7 @@ import com.typesafe.config.ConfigFactory
 
 trait Configuration {
 
-  private lazy val config = ConfigFactory.load()
+  lazy val config = ConfigFactory.load()
 
   lazy val serviceHost: String = config.getString("service.host")
 

--- a/src/main/scala/io/sdkman/vendor/release/Configuration.scala
+++ b/src/main/scala/io/sdkman/vendor/release/Configuration.scala
@@ -28,4 +28,10 @@ trait Configuration {
   lazy val serviceToken = config.getString("service.token")
 
   lazy val serviceAdminConsumer = config.getString("service.adminConsumer")
+
+  lazy val jdbcUrl = config.getString("jdbc.url")
+
+  lazy val jdbcUser = config.getString("jdbc.username")
+
+  lazy val jdbcPassword = config.getString("jdbc.password")
 }

--- a/src/main/scala/io/sdkman/vendor/release/Configuration.scala
+++ b/src/main/scala/io/sdkman/vendor/release/Configuration.scala
@@ -19,19 +19,19 @@ import com.typesafe.config.ConfigFactory
 
 trait Configuration {
 
-  lazy val config = ConfigFactory.load()
+  private lazy val config = ConfigFactory.load()
 
-  lazy val serviceHost = config.getString("service.host")
+  lazy val serviceHost: String = config.getString("service.host")
 
-  lazy val servicePort = config.getInt("service.port")
+  lazy val servicePort: Int = config.getInt("service.port")
 
-  lazy val serviceToken = config.getString("service.token")
+  lazy val serviceToken: String = config.getString("service.token")
 
-  lazy val serviceAdminConsumer = config.getString("service.adminConsumer")
+  lazy val serviceAdminConsumer: String = config.getString("service.adminConsumer")
 
-  lazy val jdbcUrl = config.getString("jdbc.url")
+  lazy val jdbcUrl: String = config.getString("jdbc.url")
 
-  lazy val jdbcUser = config.getString("jdbc.username")
+  lazy val jdbcUser: String = config.getString("jdbc.username")
 
-  lazy val jdbcPassword = config.getString("jdbc.password")
+  lazy val jdbcPassword: String = config.getString("jdbc.password")
 }

--- a/src/main/scala/io/sdkman/vendor/release/routes/Authorisation.scala
+++ b/src/main/scala/io/sdkman/vendor/release/routes/Authorisation.scala
@@ -8,9 +8,9 @@ trait Authorisation {
 
   self: Directives with Configuration =>
 
-  val CandidatesHeader = "Candidates"
+  private val CandidatesHeader = "Candidates"
 
-  val AuthTokenHeader = "Service-Token"
+  private val AuthTokenHeader = "Service-Token"
 
   def authorised(candidate: String): Directive0 = authorize { rc =>
     val headers = rc.request.headers

--- a/src/main/scala/io/sdkman/vendor/release/routes/DefaultRoutes.scala
+++ b/src/main/scala/io/sdkman/vendor/release/routes/DefaultRoutes.scala
@@ -1,6 +1,6 @@
 package io.sdkman.vendor.release.routes
 
-import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.server.{Directives, Route}
 import io.sdkman.db.{MongoConfiguration, MongoConnectivity}
 import io.sdkman.repos.{CandidatesRepo, VersionsRepo}
 import io.sdkman.vendor.release.{Configuration, HttpResponses}
@@ -19,7 +19,7 @@ trait DefaultRoutes
     with HttpResponses
     with Authorisation {
 
-  val defaultRoutes = path("default" / "version") {
+  val defaultRoutes: Route = path("default" / "version") {
     put {
       entity(as[VersionDefaultRequest]) { req =>
         authorised(req.candidate) {

--- a/src/main/scala/io/sdkman/vendor/release/routes/DefaultRoutes.scala
+++ b/src/main/scala/io/sdkman/vendor/release/routes/DefaultRoutes.scala
@@ -6,6 +6,7 @@ import io.sdkman.repos.{CandidatesRepo, VersionsRepo}
 import io.sdkman.vendor.release.{Configuration, HttpResponses}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 trait DefaultRoutes
     extends Directives
@@ -33,6 +34,7 @@ trait DefaultRoutes
                 versions.headOption
                   .map { v =>
                     updateDefaultVersion(req.candidate, req.version)
+                      .flatMap(_ => updateDefaultVersionPostgres(req.candidate, req.version))
                       .map(_ => acceptedResponse(s"Defaulted: ${req.candidate} ${req.version}"))
                   }
                   .getOrElse(
@@ -47,4 +49,7 @@ trait DefaultRoutes
       }
     }
   }
+
+  private def updateDefaultVersionPostgres(candidate: String, version: String): Future[Unit] =
+    Future.successful(Unit)
 }

--- a/src/main/scala/io/sdkman/vendor/release/routes/HealthRoutes.scala
+++ b/src/main/scala/io/sdkman/vendor/release/routes/HealthRoutes.scala
@@ -17,7 +17,7 @@ package io.sdkman.vendor.release.routes
 
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.server.{Directives, Route}
 import akka.util.ByteString
 import com.typesafe.scalalogging.LazyLogging
 import io.sdkman.db.{MongoConfiguration, MongoConnectivity}
@@ -31,7 +31,7 @@ trait HealthRoutes
     with MongoConnectivity
     with MongoConfiguration
     with LazyLogging {
-  val healthRoutes = path("alive") {
+  val healthRoutes: Route = path("alive") {
     get {
       complete {
         appCollection

--- a/src/main/scala/io/sdkman/vendor/release/routes/JsonSupport.scala
+++ b/src/main/scala/io/sdkman/vendor/release/routes/JsonSupport.scala
@@ -27,19 +27,23 @@ import spray.json.{
 }
 
 trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
-  implicit val postReleaseFormat = jsonFormat7(PostReleaseRequest)
+  implicit val postReleaseFormat: RootJsonFormat[PostReleaseRequest] =
+    jsonFormat7(PostReleaseRequest)
 
-  implicit val patchReleaseFormat = jsonFormat7(PatchReleaseRequest)
+  implicit val patchReleaseFormat: RootJsonFormat[PatchReleaseRequest] =
+    jsonFormat7(PatchReleaseRequest)
 
-  implicit val deleteReleaseFormat = jsonFormat3(DeleteReleaseRequest)
+  implicit val deleteReleaseFormat: RootJsonFormat[DeleteReleaseRequest] =
+    jsonFormat3(DeleteReleaseRequest)
 
-  implicit val versionDefaultFormat = jsonFormat2(VersionDefaultRequest)
+  implicit val versionDefaultFormat: RootJsonFormat[VersionDefaultRequest] =
+    jsonFormat2(VersionDefaultRequest)
 
   object ApiResponseJsonProtocol extends DefaultJsonProtocol {
     implicit object ApiReponseJsonFormat extends RootJsonFormat[ApiResponse] {
-      def write(ar: ApiResponse) =
+      def write(ar: ApiResponse): JsObject =
         JsObject("status" -> JsNumber(ar.status), "message" -> JsString(ar.message))
-      def read(value: JsValue) = {
+      def read(value: JsValue): ApiResponse = {
         value.asJsObject.getFields("status", "message") match {
           case Seq(JsNumber(status), JsString(message)) =>
             ApiResponse(status.intValue, message)

--- a/src/main/scala/io/sdkman/vendor/release/routes/ReleaseRoutes.scala
+++ b/src/main/scala/io/sdkman/vendor/release/routes/ReleaseRoutes.scala
@@ -41,9 +41,9 @@ trait ReleaseRoutes
     with LazyLogging
     with Authorisation {
 
-  val Universal = "UNIVERSAL"
+  private val Universal = "UNIVERSAL"
 
-  val releaseRoutes = pathPrefix("release" / "version") {
+  val releaseRoutes: Route = pathPrefix("release" / "version") {
     post {
       entity(as[PostReleaseRequest]) { req =>
         optionalHeaderValueByName("Vendor") { vendorHeader =>

--- a/src/main/scala/io/sdkman/vendor/release/routes/ReleaseRoutes.scala
+++ b/src/main/scala/io/sdkman/vendor/release/routes/ReleaseRoutes.scala
@@ -47,7 +47,7 @@ trait ReleaseRoutes
     post {
       entity(as[PostReleaseRequest]) { req =>
         optionalHeaderValueByName("Vendor") { vendorHeader =>
-          validate(req.candidate, req.version, req.platform, Some(req.url), req.checksums) {
+          validate(req.candidate, req.platform, Some(req.url), req.checksums) {
             complete {
               onFinding(req.candidate, req.version, req.platform) {
                 (candidateO, versionO, platform) =>
@@ -83,7 +83,7 @@ trait ReleaseRoutes
       }
     } ~ patch {
       entity(as[PatchReleaseRequest]) { req =>
-        validate(req.candidate, req.version, req.platform, req.url, req.checksums) {
+        validate(req.candidate, req.platform, req.url, req.checksums) {
           complete {
             onFinding(req.candidate, req.version, req.platform) {
               (candidateO, versionO, platform) =>
@@ -112,7 +112,7 @@ trait ReleaseRoutes
       }
     } ~ delete {
       entity(as[DeleteReleaseRequest]) { req =>
-        validate(req.candidate, req.version, Some(req.platform), None, None) {
+        validate(req.candidate, Some(req.platform), None, None) {
           complete {
             findCandidate(req.candidate).flatMap {
               case Some(Candidate(_, _, _, Some(default), _, _)) if default == req.version =>
@@ -137,7 +137,6 @@ trait ReleaseRoutes
 
   private def validate(
       candidate: String,
-      version: String,
       platform: Option[String],
       url: Option[String],
       checksums: Option[Map[String, String]]

--- a/src/main/scala/io/sdkman/vendor/release/routes/Validation.scala
+++ b/src/main/scala/io/sdkman/vendor/release/routes/Validation.scala
@@ -11,7 +11,7 @@ trait Validation {
   import ApiResponseJsonProtocol._
   import spray.json._
 
-  val SupportedPlatforms = Seq(
+  private val SupportedPlatforms = Seq(
     "LINUX_64",
     "LINUX_32",
     "LINUX_ARM64",
@@ -23,7 +23,7 @@ trait Validation {
     "UNIVERSAL"
   )
 
-  val AlgorithmRegex = Map(
+  private val AlgorithmRegex = Map(
     MD5.id    -> "^[a-f0-9]{32}$",
     SHA1.id   -> "^[a-f0-9]{40}$",
     SHA224.id -> "^[a-f0-9]{56}$",


### PR DESCRIPTION
We are migrating away from Mongo to Postgres :tada: 

This is the first step to introduce a data migration that primes the `version` table and adds a dummy persistence workflow for releases. These persistence workflows will operate in tandem with existing Mongo persistence for the time being. 

A subsequent PR will introduce the actual persistence boilerplate for persisting version releases. Candidates updates will follow in due course.